### PR TITLE
Fixed invalid cross link again

### DIFF
--- a/08_learn_more/00_validation.md
+++ b/08_learn_more/00_validation.md
@@ -183,7 +183,7 @@ You can create your own custom validator plugins. They must extend the ```mako\v
 		}
 	}
 
-> Prefix the ```$ruleName``` value with your package name and two colons (```::```) if your validator is a part of a [package](:base_url:/docs/:version:/packages:basics#configuration_i18n_and_views).
+> Prefix the ```$ruleName``` value with your package name and two colons (```::```) if your validator is a part of a [package](:base_url:/docs/:version:/packages:packages#configuration_i18n_and_views).
 
 You can register the plugin with the validation factory, thus making it avaiable to all future validator instances.
 


### PR DESCRIPTION
I did a mistake to follow the convention (directory:filename#hash) for cross links in my last PR :-)

Now it should be fixed & accurate