### PR TITLE
Fix foreign key typo in SQLite junction table

### DIFF
--- a/06_security/01_authentication.md
+++ b/06_security/01_authentication.md
@@ -494,9 +494,9 @@ CREATE TABLE `groups_users` (
 	`user_id` INTEGER NOT NULL,
 	CONSTRAINT `group_user` UNIQUE (`group_id`, `user_id`),
 	FOREIGN KEY (`group_id`)
-		REFERENCES `users` (`id`)
+		REFERENCES `groups` (`id`)
 		ON DELETE CASCADE ON UPDATE NO ACTION,
-	FOREIGN KEY (`group_id`)
+	FOREIGN KEY (`user_id`)
 		REFERENCES `users` (`id`)
 		ON DELETE CASCADE ON UPDATE NO ACTION
 );


### PR DESCRIPTION
Guess I was blind and/or drunk in the first PR, at least it's fixed now!