### PR TITLE
Update 01_gatekeeper.md

### DIFF
--- a/06_security/01_gatekeeper.md
+++ b/06_security/01_gatekeeper.md
@@ -412,7 +412,7 @@ CREATE TABLE `users` (
 	PRIMARY KEY (`id`),
 	UNIQUE KEY `username` (`username`),
 	UNIQUE KEY `email` (`email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ```
 {.language-sql}
 
@@ -426,7 +426,7 @@ CREATE TABLE `groups` (
 	`name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
 	PRIMARY KEY (`id`),
 	UNIQUE KEY `name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ```
 {.language-sql}
 

--- a/06_security/01_gatekeeper.md
+++ b/06_security/01_gatekeeper.md
@@ -447,7 +447,7 @@ CREATE TABLE `groups_users` (
 		FOREIGN KEY (`user_id`)
 		REFERENCES `users` (`id`)
 		ON DELETE CASCADE ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ```
 {.language-sql}
 [/collapse]


### PR DESCRIPTION
utf8 can only hold 3 bytes while utf8mb4 can hold 4 bytes. This is a known "bug" with MySQL.